### PR TITLE
Fixing linux support & improving beat placement accuracy

### DIFF
--- a/beat-marker.py
+++ b/beat-marker.py
@@ -91,12 +91,12 @@ if sys.argv[1] == "timeline":
 
     # CALCULATE INTERVAL
 
-    fps = round(project.GetSetting("timelineFrameRate"), ndigits=None)
+    fps = project.GetSetting("timelineFrameRate")
 
     if bpm == 0:
         interval = 0
     else:
-        interval = round(60 * fps / bpm)
+        interval = 60 * fps / bpm
 
     # CREATE TIMELINE MARKERS
 
@@ -107,10 +107,13 @@ if sys.argv[1] == "timeline":
 
     start = offset
     end = timeline.GetEndFrame() - timeline.GetStartFrame()
+    timestamp = start
     count = 1
 
-    for i in range(start, end, interval):
-        timeline.AddMarker(i, "Sand", "Beat " + str(count), "", 1)
+    while timestamp < end:
+        frame = round(timestamp + interval, ndigits=None)
+        timeline.AddMarker(frame, "Sand", "Beat " + str(count), "", 1)
+        timestamp += interval
         count += 1
 
 elif sys.argv[1] == "clip":

--- a/beat-marker.py
+++ b/beat-marker.py
@@ -20,7 +20,7 @@ except ImportError:
             'PROGRAMDATA') + "\\Blackmagic Design\\DaVinci Resolve\\Support\\Developer\\Scripting\\Modules\\"
 
     elif sys.platform.startswith("linux"):
-        davinci_path = "/opt/resolve/libs/Fusion/Modules/"
+        davinci_path = "/opt/resolve/Developer/Scripting/Modules/"
 
     else:
         davinci_path = ""


### PR DESCRIPTION
Previously the beat interval was rounded to an integer value once, introducing an error which is accumulated by subsequent additions.

For a project I'm working on, this ended up being 200ms at the end of a 3:20 min song, which is already quite noticeable.

With this change, the value is internally kept as a floating point value and only rounded once each beat's frame is calculated.